### PR TITLE
create components: card, deck, wrapper, layout and style adding to them

### DIFF
--- a/src/components/blocks/Footer.tsx
+++ b/src/components/blocks/Footer.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Typography, Box} from '@mui/material'
+import { useStyles } from '../../theme/style'
+
+const Footer = () => {
+  const { footer, footerContext } = useStyles()
+   return (
+     <footer className={footer}>
+       <Box  className={footerContext}>
+         <Typography component="p" color="text.secondary">
+            © {new Date().getFullYear()}
+        </Typography>
+       </Box>
+     </footer>
+    )
+}
+
+export default Footer

--- a/src/components/blocks/Header.tsx
+++ b/src/components/blocks/Header.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Button from '@mui/material/Button';
+import { Add } from '@mui/icons-material';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+import { useStyles } from '../../theme/style'
+
+function Header() {
+  const { header, headerButtons } = useStyles()
+  return (
+    <AppBar color='inherit'>
+      <Toolbar className={header}>
+        <Link href="#" underline="none">
+          <Typography variant='h5'>BrainStorm</Typography> 
+        </Link>
+        <Box className={headerButtons}>
+          <Button variant="outlined" color="success" startIcon={<Add />} >Add</Button>
+          <Button color="inherit">Decks</Button>
+        </Box>
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+export default Header

--- a/src/components/flashCard/FlashCard.tsx
+++ b/src/components/flashCard/FlashCard.tsx
@@ -1,0 +1,39 @@
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Rating from '@mui/material/Rating';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import { Delete } from '@mui/icons-material';
+import Grid from '@mui/material/Grid';
+
+import { useStyles } from '../../theme/style'
+
+function FlashCard() {
+  const { flashCard, flashCardContext, flashCardAction } = useStyles()
+    return (
+      <Grid item xs={12} md={4}>
+        <Card className={flashCard}>
+          <CardContent className={flashCardContext}>
+            <Typography gutterBottom variant="h5">
+              Cat
+            </Typography>
+          </CardContent>
+          <CardActions className={flashCardAction}>
+            <Stack spacing={1}>
+              <Rating name="half-rating" defaultValue={0} precision={0.5} />
+            </Stack>
+            <Box>
+              <IconButton color='error' aria-label='delete card'>
+                <Delete />
+              </IconButton>
+            </Box>
+          </CardActions>
+        </Card>
+      </Grid>
+    )
+}
+
+export default FlashCard

--- a/src/components/flashCard/FlashCardsCollection.tsx
+++ b/src/components/flashCard/FlashCardsCollection.tsx
@@ -1,0 +1,12 @@
+import FlashCard from './FlashCard';
+import GridsWrapperProps from '../wrappers/GridsWrapper';
+
+function FlashCardsCollection() {
+  return (
+    <GridsWrapperProps>
+      <FlashCard />
+    </GridsWrapperProps>
+  )
+}
+
+export default FlashCardsCollection

--- a/src/components/flashCardsDeck/FlashCardsDeck.tsx
+++ b/src/components/flashCardsDeck/FlashCardsDeck.tsx
@@ -1,0 +1,41 @@
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import { Add, Delete } from '@mui/icons-material';
+import Grid from '@mui/material/Grid';
+
+import { useStyles } from '../../theme/style'
+
+function FlashCardsDeck() {
+  const { flashCardsDeck, flashCardsDeckContext, flashCardsDeckActions} = useStyles()
+    return (
+      <Grid item xs={12} md={4}>
+        <Card className={flashCardsDeck}>
+          <CardContent className={flashCardsDeckContext}>
+            <Typography gutterBottom variant="h5">
+              Animals
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Lizards are a widespread group of squamate reptiles, with over 6,000
+              species, ranging across all continents except Antarctica
+            </Typography>
+            <Typography component='p' color="text.secondary">
+              Total 10
+            </Typography>
+          </CardContent>
+          <CardActions className={flashCardsDeckActions}>
+            <IconButton color='success' aria-label='add card'>
+              <Add />
+            </IconButton>
+            <IconButton color='error' aria-label='delete deck'>
+              <Delete />
+            </IconButton>
+          </CardActions>
+        </Card>
+      </Grid>
+    )
+}
+
+export default FlashCardsDeck

--- a/src/components/flashCardsDeck/FlashCardsDeckCollection.tsx
+++ b/src/components/flashCardsDeck/FlashCardsDeckCollection.tsx
@@ -1,0 +1,12 @@
+import FlashCardsDeck from './FlashCardsDeck';
+import GridsWrapperProps from '../wrappers/GridsWrapper';
+
+function FlashCardsDeckCollection() {
+  return (
+    <GridsWrapperProps>
+      <FlashCardsDeck />
+    </GridsWrapperProps>
+  )
+}
+
+export default FlashCardsDeckCollection

--- a/src/components/forms/DataManagementForm.tsx
+++ b/src/components/forms/DataManagementForm.tsx
@@ -1,0 +1,55 @@
+import { useForm } from 'react-hook-form';
+import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogTitle from '@mui/material/DialogTitle';
+
+import FormsInput from './FormsInput';
+import FormsButton from './FormsButton'
+
+import { DataManagementFormProps } from './type'
+import { IFormInput } from './interface'
+import { useStyles } from '../../theme/style'
+
+function DataManagementForm({ open, handleClickCloseModal, onSubmit, buttonFunctions, formItems }: DataManagementFormProps) {
+  const { formTitle, formInputs } = useStyles()
+
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<IFormInput>();
+
+  return (
+    <Box >
+      <Dialog
+        open={open}
+        onClose={handleClickCloseModal}
+      >
+        <DialogTitle className={formTitle}>
+          {formItems.header}
+        </DialogTitle>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          {!formItems?.isWarningForm &&
+            <Box className={formInputs}>
+              {formItems.forms?.map((form: string) => {
+                return (
+                  <FormsInput key={form} control={control} errors={errors} form={form} />
+                )
+              })}
+            </Box>
+          }
+          <DialogActions>
+            {formItems.buttons.map((button: string) => {
+              return (
+                <FormsButton key={button} button={button} buttonFunctions={buttonFunctions} />
+              )
+            })}
+          </DialogActions>
+        </form>
+      </Dialog>
+    </Box>
+  );
+}
+
+export default DataManagementForm

--- a/src/components/forms/FormsButton.tsx
+++ b/src/components/forms/FormsButton.tsx
@@ -1,0 +1,13 @@
+import Button from '@mui/material/Button';
+import { FormsButtonProps } from './type'
+
+import { createButtonsProps } from '../../helper/helper'
+
+function FormsButton(props: FormsButtonProps) {
+    const buttonProps: any = createButtonsProps(props)
+    return (
+        <Button {...buttonProps} >{props.button}</Button>
+    )
+}
+
+export default FormsButton

--- a/src/components/forms/FormsInput.tsx
+++ b/src/components/forms/FormsInput.tsx
@@ -1,0 +1,21 @@
+import { Controller } from 'react-hook-form';
+import TextField from '@mui/material/TextField';
+
+import { FormsInputProps } from './type'
+import { createInputsProps } from '../../helper/helper'
+
+function FormsInput({ control, errors, form }: FormsInputProps) {
+  const inputProps = createInputsProps(errors, form)
+
+  return (
+    <>
+      <Controller
+        render={({ field }) => <TextField {...field}  {...inputProps} />}
+        control={control}
+        rules={{ required: true, minLength: 1 }}
+        name={form || ' '} />
+    </>
+  )
+}
+
+export default FormsInput

--- a/src/components/forms/interface.ts
+++ b/src/components/forms/interface.ts
@@ -1,0 +1,9 @@
+export interface OnSubmitProps {
+  [key: string]: string;
+}
+
+export interface IFormInput {
+  [key: string]: string;
+}
+
+

--- a/src/components/forms/type.ts
+++ b/src/components/forms/type.ts
@@ -1,0 +1,25 @@
+import { Control, FieldError } from 'react-hook-form';
+
+import { OnSubmitProps, IFormInput }  from './interface'
+import { ButtonFunctionsItems } from '../hoc/interface'
+import { FormPropsItems } from '../../helper/interface';
+
+export type DataManagementFormProps = {
+  open: boolean;
+  handleClickCloseModal: () => void;
+  onSubmit: (data: OnSubmitProps) => void;
+  formItems: FormPropsItems;
+  buttonFunctions: ButtonFunctionsItems
+};
+
+export type FormsInputProps = {
+  control: Control<IFormInput, object>;
+  errors: { [x: string]: FieldError };
+  form: string;
+};
+
+export type FormsButtonProps = {
+    button: string;
+    buttonFunctions: ButtonFunctionsItems
+  };
+  

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,0 +1,20 @@
+import Header from '../blocks/Header';
+import Footer from '../blocks/Footer';
+
+import { LayoutsProps } from '../types/type';
+import { useStyles } from '../../theme/style'
+
+function Layout({ children }: LayoutsProps) {
+  const { wrapper, main } = useStyles()
+  return (
+    <div className={wrapper}>
+      <Header />
+      <main className={main}>
+        {children}
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default Layout

--- a/src/components/types/type.ts
+++ b/src/components/types/type.ts
@@ -1,0 +1,4 @@
+export type LayoutsProps = {
+  children: React.ReactNode
+}
+export type GridsWrapperProps = LayoutsProps

--- a/src/components/wrappers/GridsWrapper.tsx
+++ b/src/components/wrappers/GridsWrapper.tsx
@@ -1,0 +1,12 @@
+import Grid from '@mui/material/Grid';
+import { GridsWrapperProps } from '../types/type'
+
+function GridsWrapper({ children }: GridsWrapperProps) {
+  return (
+    <Grid container spacing={2}>
+      {children}
+    </Grid>
+  )
+}
+
+export default GridsWrapper

--- a/src/helper/helper.ts
+++ b/src/helper/helper.ts
@@ -1,0 +1,78 @@
+import {
+  FormProps,
+  ButtonsColorItems,
+  ButtonsTypeItems,
+  CreateButtonsProps,
+  InputPropsItems,
+  ButtonPropsItems,
+} from "./interface";
+import { FieldError } from "react-hook-form";
+
+const formProps: FormProps = {
+  addCard: {
+    header: "You are creating new card.",
+    forms: ["New word", "Translation"],
+    buttons: ["cancel", "save"],
+  },
+  addDeck: {
+    header: "You are creating new deck.",
+    forms: ["Title", "Description"],
+    buttons: ["cancel", "save"],
+  },
+  deleteItems: {
+    header: "Are you sure you want to delete this item?",
+    isWarningForm: true,
+    buttons: ["cancel", "delete"],
+  },
+};
+
+const buttonsColor: ButtonsColorItems = {
+  cancel: "primary",
+  save: "success",
+  delete: "error",
+};
+
+const buttonsType: ButtonsTypeItems = {
+  cancel: "reset",
+  save: "submit",
+  delete: "submit",
+};
+
+function createButtonsProps(data: CreateButtonsProps): ButtonPropsItems {
+  const { button, buttonFunctions } = data;
+
+  const buttonProps: ButtonPropsItems = {
+    type: buttonsType[button],
+    color: buttonsColor[button],
+  };
+
+  if (buttonFunctions[button]) {
+    buttonProps.onClick = buttonFunctions[button];
+  }
+
+  return buttonProps;
+}
+
+function createInputsProps(
+  errors: { [x: string]: FieldError },
+  form: string
+): InputPropsItems {
+  const isValidForm: FieldError = errors[form || ""];
+
+  const inputProps: InputPropsItems = {
+    label: form,
+    error: !!isValidForm,
+    variant: "outlined",
+    helperText: isValidForm && "This field is required",
+  };
+
+  return inputProps;
+}
+
+export {
+  formProps,
+  buttonsColor,
+  buttonsType,
+  createButtonsProps,
+  createInputsProps,
+};

--- a/src/helper/interface.ts
+++ b/src/helper/interface.ts
@@ -1,0 +1,34 @@
+export interface FormPropsItems {
+  header: string;
+  forms?: string[];
+  isWarningForm?: boolean;
+  buttons: string[];
+}
+
+export interface FormProps {
+  [x: string]: FormPropsItems;
+}
+
+export interface ButtonsColorItems {
+  [key: string]: string;
+}
+
+export interface ButtonsTypeItems extends ButtonsColorItems {}
+
+export interface CreateButtonsProps {
+  button: string;
+  buttonFunctions: { [key: string]: () => void };
+}
+
+export interface ButtonPropsItems {
+  type: string;
+  color: string;
+  onClick?: () => void;
+}
+
+export interface InputPropsItems {
+  label: string;
+  error: boolean;
+  variant: any;
+  helperText: string;
+}

--- a/src/theme/style.js
+++ b/src/theme/style.js
@@ -1,0 +1,63 @@
+import { makeStyles } from "@mui/styles";
+
+export const useStyles = makeStyles((theme) => ({
+  wrapper: {
+    minHeight: "100%",
+    display: "flex",
+    flexDirection: "column",
+  },
+  header:{
+    ...theme.itemsPosition,
+  },
+  headerButtons: {
+    ...theme.itemsPosition,
+    width: 170,
+  },
+  main: {
+    marginTop: 50,
+    padding: 30,
+  },
+  footer: {
+    position: "fixed",
+    bottom: 0,
+    zIndex: -1,
+    width: "100%",
+    height: 80,
+    backgroundColor: theme.palette.grey[200],
+  },
+  footerContext: {
+    height: "100%",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  flashCardsDeck: {
+    maxWidth: 500,
+  },
+  flashCardsDeckContext: {
+    display: "flex",
+    flexDirection: "column",
+    "& p": {
+      paddingTop: 10,
+    },
+  },
+  flashCardsDeckActions: {
+    display: "flex",
+    justifyContent: "flex-end",
+  },
+  flashCard: {
+    marginTop: 50,
+    width: 500,
+    height: 180,
+  },
+  flashCardContext: {
+    display: "flex",
+    height: 90,
+    justifyContent: "center",
+    alignItems: "flex-end",
+  },
+  flashCardAction: {
+    ...theme.itemsPosition,
+    height: 40,
+  },
+}));

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,0 +1,10 @@
+import { createTheme } from "@material-ui/core";
+
+const theme = createTheme({
+  itemsPosition: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+});
+
+export default theme;


### PR DESCRIPTION
Task #1:
  - SPA, no auth logic, no profiles management
  - Simple page with the ability to create Decks (Stacks of cards) and add Cards to them
  - Review mode to look through all cards step by step or all-in-one page
  - For the first milestone
      - the card content can be simple text with no formatting
      - all data can be stored in browser storage (e.g. localstorage)
  - UI framework is up to you, options:
    - Any CSS framework (e.g. Bootstrap, TailwindCSS)
    - Any React wrappers for UI frameworks (e.g. react-bootstrap, fomantic-ui)
    - Or no ui frameworks at all, just bare css.


Implementation:

- 444a07c

   - created components for card, deck, wrapper and layout.
   - added basic style for that components.

-  48eb26a

   -  created forms components (modals: 'delete card or deck', 'add card', 'add deck') for working with user. projects/1#card-75964945

   -  created helper and added  settings for forms components ( input and  button).

   -  made typization of all. https://github.com/Biven160690/BrainStorm/projects/1#card-76004591